### PR TITLE
Separate logic from rendering

### DIFF
--- a/event_handler.py
+++ b/event_handler.py
@@ -1,63 +1,22 @@
-import game
 import pygame
-import tile
+from renderer import GameRenderer
 
 
-def     handle_events(game_obj, events):
+def handle_events(renderer: GameRenderer, events):
     for event in events:
         if event.type == pygame.QUIT:
-            game_obj.running = False
+            renderer.game.running = False
         elif event.type == pygame.KEYDOWN:
             if event.key == pygame.K_ESCAPE:
-                game_obj.running = False
+                renderer.game.running = False
             if event.key == pygame.K_z or pygame.K_UP == event.key:
-                move_tiles(game_obj, 0, -1)
+                renderer.move(0, -1)
             if event.key == pygame.K_s or pygame.K_DOWN == event.key:
-                move_tiles(game_obj, 0, 1)
+                renderer.move(0, 1)
             if event.key == pygame.K_q or pygame.K_LEFT == event.key:
-                move_tiles(game_obj, -1, 0)
-            if event.key == pygame.K_d or pygame.K_RIGHT== event.key:
-                move_tiles(game_obj, 1, 0)
+                renderer.move(-1, 0)
+            if event.key == pygame.K_d or pygame.K_RIGHT == event.key:
+                renderer.move(1, 0)
             if event.key == pygame.K_r:
-                game.start_game(game_obj)
-
-
-def     move_tiles(game_obj, dx, dy):
-    moved = False
-    merged = [[False for _ in range(4)] for _ in range(4)]
-
-    range_x = range(4) if dx == -1 else range(3, -1, -1) if dx == 1 else range(4)
-    range_y = range(4) if dy == -1 else range(3, -1, -1) if dy == 1 else range(4)
-
-    for x in range_x:
-        for y in range_y:
-            if game_obj.tiles[x][y].value != 0:
-                val = game_obj.tiles[x][y].value
-                curr_x, curr_y = x, y
-                next_x, next_y = x + dx, y + dy
-                while 0 <= next_x < 4 and 0 <= next_y < 4 and game_obj.tiles[next_x][next_y].value == 0:
-                    game_obj.tiles[next_x][next_y].value = game_obj.tiles[curr_x][curr_y].value
-                    game_obj.tiles[curr_x][curr_y].value = 0
-                    curr_x, curr_y = next_x, next_y
-                    next_x, next_y = curr_x + dx, curr_y + dy
-                    moved = True
-                merge = False
-                if 0 <= next_x < 4 and 0 <= next_y < 4 and game_obj.tiles[next_x][next_y].value == game_obj.tiles[curr_x][curr_y].value and not merged[next_x][next_y]:
-                    game_obj.tiles[next_x][next_y].value *= 2
-                    game_obj.score += game_obj.tiles[next_x][next_y].value
-                    game_obj.tiles[curr_x][curr_y].value = 0
-                    merged[next_x][next_y] = True
-                    moved = True
-                    merge = True
-                    dest_x, dest_y = next_x, next_y
-                else:
-                    dest_x, dest_y = curr_x, curr_y
-
-                if dest_x != x or dest_y != y:
-                    anim = tile.Tile(dest_x, dest_y, value=val)
-                    anim.start_move((x, y), (dest_x, dest_y), 0.1, merge=merge)
-                    game_obj.anim_tiles.append(anim)
-                    game_obj.tiles[dest_x][dest_y].visible = False
-    if moved:
-        game.put_random_tile(game_obj)
-
+                renderer.game.reset()
+                renderer.sync_from_logic()

--- a/game_logic.py
+++ b/game_logic.py
@@ -1,0 +1,78 @@
+# Game logic module separated from rendering
+import random
+
+class Game:
+    def __init__(self):
+        self.score = 0
+        self.running = True
+        self.board = [[0 for _ in range(4)] for _ in range(4)]
+
+    def reset(self):
+        """Start a new game."""
+        self.score = 0
+        for x in range(4):
+            for y in range(4):
+                self.board[x][y] = 0
+        for _ in range(2):
+            self.put_random_tile()
+
+    def put_random_tile(self):
+        """Put a new tile on a random empty cell."""
+        empty = [(x, y) for x in range(4) for y in range(4) if self.board[x][y] == 0]
+        if not empty:
+            return None
+        x, y = random.choice(empty)
+        self.board[x][y] = random.choice((2,) * 9 + (4,))
+        return x, y
+
+    def is_game_over(self):
+        for x in range(4):
+            for y in range(4):
+                val = self.board[x][y]
+                if val == 0:
+                    return False
+                for dx, dy in [(1, 0), (-1, 0), (0, 1), (0, -1)]:
+                    nx, ny = x + dx, y + dy
+                    if 0 <= nx < 4 and 0 <= ny < 4:
+                        if self.board[nx][ny] == val:
+                            return False
+        return True
+
+    def move(self, dx: int, dy: int):
+        """Move tiles on the board. Returns the operations list and the new tile position."""
+        moved = False
+        merged = [[False for _ in range(4)] for _ in range(4)]
+        operations = []
+
+        range_x = range(4) if dx == -1 else range(3, -1, -1) if dx == 1 else range(4)
+        range_y = range(4) if dy == -1 else range(3, -1, -1) if dy == 1 else range(4)
+
+        for x in range_x:
+            for y in range_y:
+                if self.board[x][y] != 0:
+                    val = self.board[x][y]
+                    curr_x, curr_y = x, y
+                    next_x, next_y = x + dx, y + dy
+                    while 0 <= next_x < 4 and 0 <= next_y < 4 and self.board[next_x][next_y] == 0:
+                        self.board[next_x][next_y] = self.board[curr_x][curr_y]
+                        self.board[curr_x][curr_y] = 0
+                        curr_x, curr_y = next_x, next_y
+                        next_x, next_y = curr_x + dx, curr_y + dy
+                        moved = True
+                    merge = False
+                    if 0 <= next_x < 4 and 0 <= next_y < 4 and self.board[next_x][next_y] == self.board[curr_x][curr_y] and not merged[next_x][next_y]:
+                        self.board[next_x][next_y] *= 2
+                        self.score += self.board[next_x][next_y]
+                        self.board[curr_x][curr_y] = 0
+                        merged[next_x][next_y] = True
+                        moved = True
+                        merge = True
+                        dest_x, dest_y = next_x, next_y
+                    else:
+                        dest_x, dest_y = curr_x, curr_y
+                    if dest_x != x or dest_y != y:
+                        operations.append({"from": (x, y), "to": (dest_x, dest_y), "value": val, "merge": merge})
+        new_tile = None
+        if moved:
+            new_tile = self.put_random_tile()
+        return operations, new_tile

--- a/main.py
+++ b/main.py
@@ -1,29 +1,31 @@
 import pygame
 from constants import TILE_SIZE, SCREEN_WIDTH, SCREEN_HEIGHT, FPS, LOGO_SIZE, SCORE_SIZE
 import tile
-import game as game_module
+from game_logic import Game
+import renderer
 import event_handler as event
 
 if __name__ == '__main__':
     pygame.init()
 
     tile.game_font = pygame.font.SysFont("monospace", int(TILE_SIZE / 4), bold=True)
-    game_module.logo_font = pygame.font.SysFont("monospace", LOGO_SIZE, bold=True)
-    game_module.score_font = pygame.font.SysFont("monospace", SCORE_SIZE, bold=True)
+    renderer.logo_font = pygame.font.SysFont("monospace", LOGO_SIZE, bold=True)
+    renderer.score_font = pygame.font.SysFont("monospace", SCORE_SIZE, bold=True)
 
     screen = pygame.display.set_mode((SCREEN_WIDTH, SCREEN_HEIGHT), pygame.NOFRAME)
     clock = pygame.time.Clock()
     dt = 0
 
-    game = game_module.Game()
-    game_module.start_game(game)
+    game = Game()
+    game.reset()
+    view = renderer.GameRenderer(game)
+
     while game.running:
-        event.handle_events(game, pygame.event.get())
-        game.update(dt)
-        game.render(screen)
-        if game_module.is_game_over(game):
-            game_module.render_game_over(screen)
+        event.handle_events(view, pygame.event.get())
+        view.update(dt)
+        view.render(screen)
+        if game.is_game_over():
+            renderer.render_game_over(screen)
         pygame.display.flip()
         dt = clock.tick(FPS) / 1000
     pygame.quit()
-


### PR DESCRIPTION
## Summary
- implement standalone game logic module
- move rendering duties to renderer.py
- update event handler and main entrypoint to use new modules
- remove old game module

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_685b6eaf82a88324b82bfcc04e628ab3